### PR TITLE
Update deprecated hook ongenerate to generateBundle

### DIFF
--- a/lib/rollup-plugin-purgecss.es.js
+++ b/lib/rollup-plugin-purgecss.es.js
@@ -33,7 +33,7 @@ const pluginPurgecss = function (options = {}) {
                 map: { mappings: '' }
             };
         },
-        ongenerate() {
+        generateBundle() {
             if (!options.insert && (!styles.length || options.output === false)) {
                 return;
             }

--- a/lib/rollup-plugin-purgecss.js
+++ b/lib/rollup-plugin-purgecss.js
@@ -37,7 +37,7 @@ const pluginPurgecss = function (options = {}) {
                 map: { mappings: '' }
             };
         },
-        ongenerate() {
+        generateBundle() {
             if (!options.insert && (!styles.length || options.output === false)) {
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-purgecss",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rollup plugin for purgecss",
   "main": "lib/rollup-plugin-purgecss.js",
   "module": "./lib/rollup-plugin-purgecss.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const pluginPurgecss = function( options = {} ) {
                 map: { mappings: '' }
             }
         },
-        ongenerate() {
+        generateBundle() {
             if (!options.insert && (!styles.length || options.output === false)) {
                 return
             }


### PR DESCRIPTION
## Proposed changes

Rollup has deprecated the "ongenerate" hook and throws a warning on every build.

> (!) The "ongenerate" hook used by plugin purgecss is deprecated. The "generateBundle" hook should be used instead.

This change simply swaps out one method for the other so the warning is no longer thrown.
